### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # YXTPageView
-##A Page View, which support scrolling to transition between a UIView and a UITableView
+## A Page View, which support scrolling to transition between a UIView and a UITableView
 
 UIView (at the top)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
